### PR TITLE
Remove any trailing dashes in 53-char helm release name

### DIFF
--- a/lib/stax/helm/base.rb
+++ b/lib/stax/helm/base.rb
@@ -8,7 +8,7 @@ module Stax
 
       ## make string safe to use in naming helm stuff
       def helm_safe(string)
-        string.slice(0, 53).gsub(/[\W_]/, '-').downcase
+        string.slice(0, 53).gsub(/[\W_]/, '-').sub(/-+$/, '').downcase
       end
     end
 


### PR DESCRIPTION
Closes #2

helm release names must have max length of 53 chars, due to underlying k8s service name limitations.

Ref: https://github.com/helm/helm/blob/main/pkg/action/install.go#L62

This may be relaxed in future, see: https://github.com/helm/helm/pull/8384

Truncating the name to fit this constraint, and converting non-word chars to dashes, can leave us with a release name ending in one or more dashes, which is not permitted.

The quick-and-dirty solution is to remove any trailing dashes after truncation.