### PR TITLE
Make open3 a gem dependency 

### DIFF
--- a/lib/stax/helm/runcmd.rb
+++ b/lib/stax/helm/runcmd.rb
@@ -1,3 +1,4 @@
+require 'open3'
 require 'securerandom'
 
 module Stax

--- a/lib/stax/helm/version.rb
+++ b/lib/stax/helm/version.rb
@@ -1,5 +1,5 @@
 module Stax
   module Helm
-    VERSION = '0.0.12'
+    VERSION = '0.0.13'
   end
 end

--- a/stax-helm.gemspec
+++ b/stax-helm.gemspec
@@ -25,4 +25,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake', '>= 12.3.3'
 
   spec.add_dependency('stax')
+  spec.add_dependency('open3')
 end


### PR DESCRIPTION
This fixes an error I ran into while using this gem:

```
➜  app-api dev-admin git:(main) ✗ stax helm run
[DEBUG] Creating job app-api-main-run-5e0d1b25
Error from server (NotFound): jobs.batch "app-api-main-run-5e0d1b25" not found
bundler: failed to load command: stax (/Users/clifff/.rbenv/versions/2.7.4/bin/stax)
Traceback (most recent call last):
	27: from /Users/clifff/.rbenv/versions/2.7.4/bin/bundle:23:in `<main>'
	26: from /Users/clifff/.rbenv/versions/2.7.4/bin/bundle:23:in `load'
	25: from /Users/clifff/.rbenv/versions/2.7.4/lib/ruby/gems/2.7.0/gems/bundler-2.2.19/exe/bundle:37:in `<top (required)>'
	24: from /Users/clifff/.rbenv/versions/2.7.4/lib/ruby/gems/2.7.0/gems/bundler-2.2.19/lib/bundler/friendly_errors.rb:130:in `with_friendly_errors'
	23: from /Users/clifff/.rbenv/versions/2.7.4/lib/ruby/gems/2.7.0/gems/bundler-2.2.19/exe/bundle:49:in `block in <top (required)>'
	22: from /Users/clifff/.rbenv/versions/2.7.4/lib/ruby/gems/2.7.0/gems/bundler-2.2.19/lib/bundler/cli.rb:24:in `start'
	21: from /Users/clifff/.rbenv/versions/2.7.4/lib/ruby/gems/2.7.0/gems/bundler-2.2.19/lib/bundler/vendor/thor/lib/thor/base.rb:485:in `start'
	20: from /Users/clifff/.rbenv/versions/2.7.4/lib/ruby/gems/2.7.0/gems/bundler-2.2.19/lib/bundler/cli.rb:30:in `dispatch'
	19: from /Users/clifff/.rbenv/versions/2.7.4/lib/ruby/gems/2.7.0/gems/bundler-2.2.19/lib/bundler/vendor/thor/lib/thor.rb:392:in `dispatch'
	18: from /Users/clifff/.rbenv/versions/2.7.4/lib/ruby/gems/2.7.0/gems/bundler-2.2.19/lib/bundler/vendor/thor/lib/thor/invocation.rb:127:in `invoke_command'
	17: from /Users/clifff/.rbenv/versions/2.7.4/lib/ruby/gems/2.7.0/gems/bundler-2.2.19/lib/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
	16: from /Users/clifff/.rbenv/versions/2.7.4/lib/ruby/gems/2.7.0/gems/bundler-2.2.19/lib/bundler/cli.rb:474:in `exec'
	15: from /Users/clifff/.rbenv/versions/2.7.4/lib/ruby/gems/2.7.0/gems/bundler-2.2.19/lib/bundler/cli/exec.rb:28:in `run'
	14: from /Users/clifff/.rbenv/versions/2.7.4/lib/ruby/gems/2.7.0/gems/bundler-2.2.19/lib/bundler/cli/exec.rb:63:in `kernel_load'
	13: from /Users/clifff/.rbenv/versions/2.7.4/lib/ruby/gems/2.7.0/gems/bundler-2.2.19/lib/bundler/cli/exec.rb:63:in `load'
	12: from /Users/clifff/.rbenv/versions/2.7.4/bin/stax:23:in `<top (required)>'
	11: from /Users/clifff/.rbenv/versions/2.7.4/bin/stax:23:in `load'
	10: from /Users/clifff/.rbenv/versions/2.7.4/lib/ruby/gems/2.7.0/gems/stax-0.1.8/bin/stax:7:in `<top (required)>'
	 9: from /Users/clifff/.rbenv/versions/2.7.4/lib/ruby/gems/2.7.0/gems/thor-1.1.0/lib/thor/base.rb:485:in `start'
	 8: from /Users/clifff/.rbenv/versions/2.7.4/lib/ruby/gems/2.7.0/gems/thor-1.1.0/lib/thor.rb:392:in `dispatch'
	 7: from /Users/clifff/.rbenv/versions/2.7.4/lib/ruby/gems/2.7.0/gems/thor-1.1.0/lib/thor/invocation.rb:127:in `invoke_command'
	 6: from /Users/clifff/.rbenv/versions/2.7.4/lib/ruby/gems/2.7.0/gems/thor-1.1.0/lib/thor/command.rb:27:in `run'
	 5: from /Users/clifff/.rbenv/versions/2.7.4/lib/ruby/gems/2.7.0/gems/thor-1.1.0/lib/thor.rb:243:in `block in subcommand'
	 4: from /Users/clifff/.rbenv/versions/2.7.4/lib/ruby/gems/2.7.0/gems/thor-1.1.0/lib/thor/invocation.rb:116:in `invoke'
	 3: from /Users/clifff/.rbenv/versions/2.7.4/lib/ruby/gems/2.7.0/gems/thor-1.1.0/lib/thor.rb:392:in `dispatch'
	 2: from /Users/clifff/.rbenv/versions/2.7.4/lib/ruby/gems/2.7.0/gems/thor-1.1.0/lib/thor/invocation.rb:127:in `invoke_command'
	 1: from /Users/clifff/.rbenv/versions/2.7.4/lib/ruby/gems/2.7.0/gems/thor-1.1.0/lib/thor/command.rb:27:in `run'
/Users/clifff/.rbenv/versions/2.7.4/lib/ruby/gems/2.7.0/gems/stax-helm-0.0.12/lib/stax/helm/runcmd.rb:92:in `runcmd': uninitialized constant Stax::Helm::Cmd::Open3 (NameError)
```

I suspect this doesn't pop up in other apps because Open3 is such a common gem - I think it may be relatively recent that it was taken out of the standard library into an 'official gem'. Anyway, making it an explicit part of the gemspec seems to fix the issue.