### PR TITLE
Force run Job object name is no longer than 63 chars

### DIFF
--- a/lib/stax/helm/runcmd.rb
+++ b/lib/stax/helm/runcmd.rb
@@ -39,7 +39,9 @@ module Stax
 
         ## name for Job to create based on container
         def helm_run_job
-          "#{helm_release_name}-run-#{SecureRandom.hex(4)}"
+          suffix = "-run-#{SecureRandom.hex(4)}"
+          prefix = helm_release_name.slice(0,63-suffix.length).sub(/-+$/, '') # ensure total name is <=63 chars
+          prefix + suffix
         end
 
         ## default command to run


### PR DESCRIPTION
We force helm release name to be no longer than 53 chars, but then append eg `-run-12345678` to construct the Job name. This can exceed the 63 name limit in k8s when using very long git branch names.

This truncates the helm release name further based on our suffix length.