### PR TITLE
Avoid karpenter disruption when running cmd

### DIFF
--- a/lib/stax/helm/runcmd.rb
+++ b/lib/stax/helm/runcmd.rb
@@ -15,6 +15,9 @@ module Stax
               name: name,
               labels: {
                 'app.kubernetes.io/managed-by' => :stax
+              },
+              annotations: {
+                'karpenter.sh/do-not-disrupt' => :true
               }
             },
             spec: {


### PR DESCRIPTION
Avoid karpenter disruption when running cmd

If this makes `runcmd` too opinionated to our particular setup, we can think of an alternative way to interject this annotation into the runcmd job.